### PR TITLE
Catch NoNameservers from DNS Resolver

### DIFF
--- a/gs/dmarc/lookup.py
+++ b/gs/dmarc/lookup.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import, unicode_literals
 from enum import Enum
 from os.path import join as path_join
-from dns.resolver import query as dns_query, NXDOMAIN, NoAnswer
+from dns.resolver import query as dns_query, NXDOMAIN, NoAnswer, NoNameserver
 from publicsuffix import PublicSuffixList
 
 
@@ -62,7 +62,7 @@ def lookup_receiver_policy(host):
     retval = ReceiverPolicy.noDmarc
     try:
         dnsAnswer = dns_query(dmarcHost, 'TXT')
-    except (NXDOMAIN, NoAnswer):
+    except (NXDOMAIN, NoAnswer, NoNameserver):
         pass  # retval = ReceiverPolicy.noDmarc
     else:
         answer = str(dnsAnswer[0])


### PR DESCRIPTION
Had someone from a @ucdavis.edu email attempt to post to my GroupServer group.

Got the following error:

```
2015-08-28T18:39:19 ERROR Zope.SiteErrorLog 1440801559.260.221945513664
http://list.abrf.org/gs-group-messages-add-email.html
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module zope.formlib.form, line 795, in __call__
  Module five.formlib.formbase, line 50, in update
  Module zope.formlib.form, line 776, in update
  Module zope.formlib.form, line 620, in success
  Module gs.group.messages.add.base.addemail, line 50, in handle_add
  Module gs.group.messages.add.base.adder, line 45, in add
  Module Products.XWFMailingListManager.XWFMailingList, line 132, in
manage_mailboxer
  Module Products.XWFMailingListManager.XWFMailingList, line 513, in
processMail
  Module Products.XWFMailingListManager.XWFMailingList, line 475, in listMail
  Module gs.group.list.sender.sender, line 57, in send
  Module gs.group.list.sender.modifyheaders, line 108, in modify_headers
  Module gs.group.list.sender.modifyheaders, line 62, in modify_headers
  Module gs.group.list.sender.headers.frm, line 163, in modify_header
  Module gs.cache.decorator, line 27, in do_cache
  Module gs.group.list.sender.headers.frm, line 71, in
get_dmarc_policy_for_host
  Module gs.dmarc.lookup, line 64, in lookup_receiver_policy
  Module dns.resolver, line 974, in query
  Module dns.resolver, line 817, in query
NoNameservers
```

Server is using Google's DNS (8.8.8.8 & 8.8.4.4).

```
$ dig TXT _dmarc.ucdavis.edu @8.8.8.8
```

Returns "status: SERVFAIL" which causes the NoNameservers exception

Trying again using OpenDNS:

```
$ dig TXT _dmarc.ucdavis.edu @208.67.222.222
```

Which returns "status: NXDOMAIN".