### PR TITLE
Corresponds to Multiple Strings in a Single DNS record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 ---
 language: python
+python:
+     - "2.7"
+     - "3.4"
+     - "3.5"
+     - "3.6"
 install:
-  - pip install tox
-script: tox
+    - pip install .
+    - pip install nose
+script:
+    - python setup.py test
+sudo: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+---
+language: python
+install:
+  - pip install tox
+script: tox

--- a/gs/dmarc/lookup.py
+++ b/gs/dmarc/lookup.py
@@ -12,17 +12,20 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ############################################################################
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import absolute_import, print_function, unicode_literals
+
 from enum import Enum
+
+from dns.resolver import NXDOMAIN, NoAnswer, NoNameservers
+from dns.resolver import query as dns_query
 from pkg_resources import resource_filename  # Part of setuptools
+from publicsuffix import PublicSuffixList
+
 try:
     # typing is needed by mypy, but is unused otherwise
     from typing import Dict, Text  # noqa: F401
 except ImportError:
     pass
-from dns.resolver import (query as dns_query, NXDOMAIN, NoAnswer,
-                          NoNameservers)
-from publicsuffix import PublicSuffixList
 
 
 class ReceiverPolicy(Enum):
@@ -49,7 +52,7 @@ class ReceiverPolicy(Enum):
 def answer_to_dict(answer):
     # type: (Text) -> Dict[unicode, unicode]
     '''Turn the DNS DMARC answer into a dict of tag:value pairs.'''
-    a = answer.strip('"').strip(' ')
+    a = answer.replace('"', '').strip(' ')
     rawTags = [t.split('=') for t in a.split(';') if t]
     retval = {t[0].strip(): t[1].strip() for t in rawTags}
     return retval

--- a/gs/dmarc/tests/test_all.py
+++ b/gs/dmarc/tests/test_all.py
@@ -13,10 +13,14 @@
 #
 ############################################################################
 from __future__ import absolute_import, unicode_literals
-from unittest import TestSuite, main as unittest_main
-from gs.dmarc.tests.lookup import TestLookup
+
+from unittest import TestSuite
+from unittest import main as unittest_main
+
+from gs.dmarc.tests.lookup import TestLookup, TestMultipleSingleRRLookup
 from gs.dmarc.tests.receiver import TestReceiverPolicy
-testCases = (TestLookup, TestReceiverPolicy)
+
+testCases = (TestLookup, TestMultipleSingleRRLookup, TestReceiverPolicy)
 
 
 def load_tests(loader, tests, pattern):
@@ -25,6 +29,7 @@ def load_tests(loader, tests, pattern):
         tests = loader.loadTestsFromTestCase(testClass)
         suite.addTests(tests)
     return suite
+
 
 if __name__ == '__main__':
     unittest_main()


### PR DESCRIPTION
## Description

Example: 
```
❯ dig +short _dmarc.email.apple.com txt
"v=DMARC1;" "p=reject;" "rua=mailto:d@rua.agari.com;" "ruf=mailto:d@ruf.agari.com;"
```

```python
>>> from gs.dmarc import receiver_policy
>>> host = 'email.apple.com'
>>> policy = receiver_policy(host)
>>> print(policy)
ReceiverPolicy.none
```

## SeeAlso
- [rfc4408#3.1.3.  Multiple Strings in a Single DNS record](https://tools.ietf.org/html/rfc4408#section-3.1.3)

## note
- fixed isort
- add travis ci test